### PR TITLE
Fix an overflow bug

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -34,7 +34,7 @@ pub fn l_capturing(len: u32) -> u8 {
         } else {
             bottom = idx + 1;
         }
-        idx = (bottom + top) / 2;
+        idx = (((bottom as u16) + (top as u16)) / 2) as u8;
     }
 }
 


### PR DESCRIPTION
Fix "thread 'main' panicked at 'attempt to add with overflow', tlsh2-0.2.0\src\util.rs:39:15" that occurs on many files when attempting to hash