### PR TITLE
Add fromStr implementation on TLSH object

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,15 +52,30 @@ pub use crate::tlsh::{Tlsh, TlshBuilder};
 
 /// Builder with 256 buckets and a 1 byte checksum.
 pub type TlshBuilder256_1 = TlshBuilder<256, 1, 64, 136, 50>;
+/// TLSH with 256 buckets and a 1 byte checksum.
+pub type Tlsh256_1 = Tlsh<1, 136, 64>;
+
 /// Builder with 128 buckets and a 1 byte checksum.
 pub type TlshBuilder128_1 = TlshBuilder<128, 1, 32, 72, 50>;
+/// TLSH with 128 buckets and a 1 byte checksum.
+pub type Tlsh128_1 = Tlsh<1, 72, 32>;
+
 /// Builder with 48 buckets and a 1 byte checksum.
 pub type TlshBuilder48_1 = TlshBuilder<48, 1, 12, 32, 10>;
+/// TLSh with 48 buckets and a 1 byte checksum.
+pub type Tlsh48_1 = Tlsh<1, 32, 12>;
 
 /// Builder with 256 buckets and a 3 bytes checksum.
 pub type TlshBuilder256_3 = TlshBuilder<256, 3, 64, 140, 50>;
+/// TLSH with 256 buckets and a 3 bytes checksum.
+pub type Tlsh256_3 = Tlsh<3, 140, 64>;
+
 /// Builder with 128 buckets and a 3 bytes checksum.
 pub type TlshBuilder128_3 = TlshBuilder<128, 3, 32, 76, 50>;
+/// TLSH with 128 buckets and a 3 bytes checksum.
+pub type Tlsh128_3 = Tlsh<3, 76, 32>;
 
 /// Default builder, using 128 buckets and a 1 byte checksum.
 pub type TlshDefaultBuilder = TlshBuilder128_1;
+/// Default TLSH, using 128 buckets and a 1 byte checksum.
+pub type TlshDefault = Tlsh128_1;

--- a/tests/it/hash.rs
+++ b/tests/it/hash.rs
@@ -21,25 +21,55 @@ where
 }
 
 macro_rules! do_hash_test {
-    ($testname:ident, $name:expr, $type:ty) => {
+    ($testname:ident, $name:expr, $builder:ty, $tlsh:ty) => {
         #[test]
         fn $testname() {
             test_hash(
                 &format!("tests/assets/tlsh/exp/example_data.{}.len.out_EXP", $name),
                 |contents| {
-                    let mut tlsh = <$type>::new();
-                    tlsh.update(contents);
-                    tlsh.build()
-                        .map(|v| String::from_utf8(v.hash().to_vec()).unwrap())
-                        .unwrap_or_default()
+                    let mut builder = <$builder>::new();
+                    builder.update(contents);
+                    let tlsh = builder.build().unwrap();
+                    let hash = String::from_utf8(tlsh.hash().to_vec()).unwrap();
+
+                    // Test the FromStr implementation
+                    let tlsh2 = hash.parse::<$tlsh>().unwrap();
+                    assert_eq!(tlsh.hash(), tlsh2.hash());
+
+                    hash
                 },
             )
         }
     };
 }
 
-do_hash_test!(test_hash_48_1, "48.1", tlsh2::TlshBuilder48_1);
-do_hash_test!(test_hash_128_1, "128.1", tlsh2::TlshBuilder128_1);
-do_hash_test!(test_hash_128_3, "128.3", tlsh2::TlshBuilder128_3);
-do_hash_test!(test_hash_256_1, "256.1", tlsh2::TlshBuilder256_1);
-do_hash_test!(test_hash_256_3, "256.3", tlsh2::TlshBuilder256_3);
+do_hash_test!(
+    test_hash_48_1,
+    "48.1",
+    tlsh2::TlshBuilder48_1,
+    tlsh2::Tlsh48_1
+);
+do_hash_test!(
+    test_hash_128_1,
+    "128.1",
+    tlsh2::TlshBuilder128_1,
+    tlsh2::Tlsh128_1
+);
+do_hash_test!(
+    test_hash_128_3,
+    "128.3",
+    tlsh2::TlshBuilder128_3,
+    tlsh2::Tlsh128_3
+);
+do_hash_test!(
+    test_hash_256_1,
+    "256.1",
+    tlsh2::TlshBuilder256_1,
+    tlsh2::Tlsh256_1
+);
+do_hash_test!(
+    test_hash_256_3,
+    "256.3",
+    tlsh2::TlshBuilder256_3,
+    tlsh2::Tlsh256_3
+);


### PR DESCRIPTION
- Add a FromStr impl on the `TLSH` object, to be able to build one from a hash string.

- Add typedefs for `Tlsh` that mirror the `TlshBuilder` typedefs. This was kind of necessary
  to be able to use this FromStr implementation without having to provide all the generic values
  by hand.

Closes #5 