### PR TITLE
feat: add fast update behind a feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
       - run: cargo test --features diff
+      - run: cargo test --features fast
 
   clippy:
     name: Clippy
@@ -31,6 +32,7 @@ jobs:
           components: clippy
       - run: cargo clippy --tests
       - run: cargo clippy --tests --features diff
+      - run: cargo clippy --tests --features fast
 
   rustfmt:
     name: Rustfmt
@@ -54,3 +56,4 @@ jobs:
           target: s390x-unknown-linux-gnu
       - run: cargo test
       - run: cargo test --features diff
+      - run: cargo test --features fast

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["algorithms"]
 # Enable ability to compute diff score between two TLSH.
 # This is behind a feature flag as it adds a 64k static array to the binary.
 diff = []
+# Enable joint lookup for faster Pearson hashing.
+# This is behind a feature flag as it adds a 64k static array to the binary.
+fast = []
 
 [dev-dependencies]
 glob = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -43,5 +43,7 @@ Those configurations are available:
 - 256 buckets and 3-byte checksum.
 - 48 buckets and 1-byte checksum.
 
+The `fast` feature speeds up TLSH generation but adds a 64kB lookup table.
+
 The `threaded` and `private` options that exists in the original TLSH version
 are not yet implemented.

--- a/src/tlsh.rs
+++ b/src/tlsh.rs
@@ -104,11 +104,11 @@ impl<
                 self.a_bucket[usize::from(r)] += 1;
                 let r = fast_b_mapping::<EFF_BUCKETS>(12, b_0, b_1, b_3);
                 self.a_bucket[usize::from(r)] += 1;
+                let r = fast_b_mapping::<EFF_BUCKETS>(84, b_0, b_1, b_4);
+                self.a_bucket[usize::from(r)] += 1;
                 let r = fast_b_mapping::<EFF_BUCKETS>(178, b_0, b_2, b_3);
                 self.a_bucket[usize::from(r)] += 1;
                 let r = fast_b_mapping::<EFF_BUCKETS>(166, b_0, b_2, b_4);
-                self.a_bucket[usize::from(r)] += 1;
-                let r = fast_b_mapping::<EFF_BUCKETS>(84, b_0, b_1, b_4);
                 self.a_bucket[usize::from(r)] += 1;
                 let r = fast_b_mapping::<EFF_BUCKETS>(230, b_0, b_3, b_4);
                 self.a_bucket[usize::from(r)] += 1;


### PR DESCRIPTION
Introduce a lookup table behind a new `fast` feature flag, to combine pairs of updates in Pearson hashing. Opt-in because the table is 64kB, much like the `diff` feature.