### PR TITLE
feat: add serialization support with serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0 OR BSD-3-Clause"
 keywords = ["tlsh", "hash", "digest", "similarity"]
 categories = ["algorithms"]
 
+[dependencies]
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
+
 [features]
 # Enable ability to compute diff score between two TLSH.
 # This is behind a feature flag as it adds a 64k static array to the binary.
@@ -19,6 +22,7 @@ fast = []
 
 [dev-dependencies]
 glob = "0.3.0"
+serde_json = "1.0"
 
 [package.metadata.docs.rs]
-features = ["diff"]
+features = ["diff", "serde"]

--- a/src/tlsh.rs
+++ b/src/tlsh.rs
@@ -13,6 +13,7 @@ const RNG_SIZE: usize = SLIDING_WND_SIZE - 1;
 ///
 /// You should never provide your own values for the generics, but instead use the pre-configured
 /// types such as [`crate::TlshBuilder256_1`] or [`crate::TlshBuilder128_3`].
+#[derive(Clone)]
 pub struct TlshBuilder<
     const EFF_BUCKETS: usize,
     const TLSH_CHECKSUM_LEN: usize,
@@ -185,6 +186,7 @@ impl<
 }
 
 /// TLSH object, from which a hash or a distance can be computed.
+#[derive(Clone)]
 pub struct Tlsh<
     const TLSH_CHECKSUM_LEN: usize,
     const TLSH_STRING_LEN_REQ: usize,

--- a/src/tlsh.rs
+++ b/src/tlsh.rs
@@ -392,3 +392,63 @@ fn to_hex(s: &mut [u8], s_idx: &mut usize, b: u8) {
     s[*s_idx + 1] = HEX_LOOKUP[i + 1];
     *s_idx += 2;
 }
+
+#[cfg(feature = "serde")]
+impl<const TLSH_CHECKSUM_LEN: usize, const TLSH_STRING_LEN_REQ: usize, const CODE_SIZE: usize>
+    serde::Serialize for Tlsh<TLSH_CHECKSUM_LEN, TLSH_STRING_LEN_REQ, CODE_SIZE>
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let hash = self.hash();
+        let s = core::str::from_utf8(&hash).map_err(serde::ser::Error::custom)?;
+        serializer.serialize_str(s)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<
+        'de,
+        const TLSH_CHECKSUM_LEN: usize,
+        const TLSH_STRING_LEN_REQ: usize,
+        const CODE_SIZE: usize,
+    > serde::Deserialize<'de> for Tlsh<TLSH_CHECKSUM_LEN, TLSH_STRING_LEN_REQ, CODE_SIZE>
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct TlshVisitor<
+            const TLSH_CHECKSUM_LEN: usize,
+            const TLSH_STRING_LEN_REQ: usize,
+            const CODE_SIZE: usize,
+        >;
+        impl<
+                'de,
+                const TLSH_CHECKSUM_LEN: usize,
+                const TLSH_STRING_LEN_REQ: usize,
+                const CODE_SIZE: usize,
+            > serde::de::Visitor<'de>
+            for TlshVisitor<TLSH_CHECKSUM_LEN, TLSH_STRING_LEN_REQ, CODE_SIZE>
+        {
+            type Value = Tlsh<TLSH_CHECKSUM_LEN, TLSH_STRING_LEN_REQ, CODE_SIZE>;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                formatter.write_str("a valid TLSH hex string")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                value
+                    .parse()
+                    .map_err(|_| serde::de::Error::custom("invalid TLSH string"))
+            }
+        }
+
+        deserializer
+            .deserialize_str(TlshVisitor::<TLSH_CHECKSUM_LEN, TLSH_STRING_LEN_REQ, CODE_SIZE>)
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -3,3 +3,6 @@ mod diff;
 mod hash;
 mod misc;
 mod tlshc;
+
+#[cfg(feature = "serde")]
+mod serde;

--- a/tests/it/serde.rs
+++ b/tests/it/serde.rs
@@ -1,0 +1,12 @@
+#[test]
+fn test_serde() {
+    let hash_str = "T12D900249414E0BD59A46503F3ADA802AE50825242B2590561CF690599112214C051556";
+    let tlsh: tlsh2::TlshDefault = hash_str.parse().unwrap();
+
+    let json = serde_json::to_string(&tlsh).unwrap();
+    // In JSON, it should be serialized as a string
+    assert_eq!(json, format!("\"{}\"", hash_str));
+
+    let tlsh_deser: tlsh2::TlshDefault = serde_json::from_str(&json).unwrap();
+    assert_eq!(tlsh.hash(), tlsh_deser.hash());
+}


### PR DESCRIPTION
It would be good if we could serialize TLSH objects. Additional tests has been added alongside with (optional) serde support